### PR TITLE
:bug: 修复通知已读操作未生效的问题，剥离两个不同对象类型的查询逻辑

### DIFF
--- a/ballcat-business-notify/ballcat-notify-biz/src/main/java/org/ballcat/business/notify/mapper/AnnouncementMapper.java
+++ b/ballcat-business-notify/ballcat-notify-biz/src/main/java/org/ballcat/business/notify/mapper/AnnouncementMapper.java
@@ -1,5 +1,7 @@
 package org.ballcat.business.notify.mapper;
 
+import java.util.List;
+
 import com.baomidou.mybatisplus.core.conditions.Wrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.core.toolkit.Constants;
@@ -16,8 +18,6 @@ import org.ballcat.common.model.domain.PageResult;
 import org.ballcat.mybatisplus.conditions.query.LambdaQueryWrapperX;
 import org.ballcat.mybatisplus.mapper.ExtendMapper;
 import org.ballcat.mybatisplus.toolkit.WrappersX;
-
-import java.util.List;
 
 /**
  * 公告信息
@@ -67,11 +67,10 @@ public interface AnnouncementMapper extends ExtendMapper<Announcement> {
 	}
 
 	/**
-	 * 根据参数获取当前用户拉取过，或者未拉取过的有效的公告信息
+	 * 根据参数获取当前用户未拉取过的有效的公告信息
 	 * @param userId 用户ID
-	 * @param pulled 当前用户是否拉取过
 	 * @return 公告信息列表
 	 */
-	List<Announcement> listUserAnnouncements(@Param("userId") Long userId, @Param("pulled") boolean pulled);
+	List<Announcement> listUnPulledUserAnnouncements(@Param("userId") Long userId);
 
 }

--- a/ballcat-business-notify/ballcat-notify-biz/src/main/java/org/ballcat/business/notify/mapper/UserAnnouncementMapper.java
+++ b/ballcat-business-notify/ballcat-notify-biz/src/main/java/org/ballcat/business/notify/mapper/UserAnnouncementMapper.java
@@ -1,20 +1,23 @@
 package org.ballcat.business.notify.mapper;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
-import org.ballcat.business.notify.enums.UserAnnouncementStateEnum;
+import org.apache.ibatis.annotations.Param;
 import org.ballcat.business.notify.converter.UserAnnouncementConverter;
+import org.ballcat.business.notify.enums.UserAnnouncementStateEnum;
 import org.ballcat.business.notify.model.entity.UserAnnouncement;
 import org.ballcat.business.notify.model.qo.UserAnnouncementQO;
 import org.ballcat.business.notify.model.vo.UserAnnouncementPageVO;
+import org.ballcat.business.notify.model.vo.UserAnnouncementVO;
 import org.ballcat.common.model.domain.PageParam;
 import org.ballcat.common.model.domain.PageResult;
 import org.ballcat.mybatisplus.conditions.query.LambdaQueryWrapperX;
 import org.ballcat.mybatisplus.mapper.ExtendMapper;
 import org.ballcat.mybatisplus.toolkit.WrappersX;
-
-import java.time.LocalDateTime;
 
 /**
  * 用户公告表
@@ -51,5 +54,12 @@ public interface UserAnnouncementMapper extends ExtendMapper<UserAnnouncement> {
 			.eq(UserAnnouncement::getUserId, userId);
 		this.update(null, wrapper);
 	}
+
+	/**
+	 * 根据参数获取当前用户拉取过的有效的公告信息
+	 * @param userId 用户ID
+	 * @return 公告信息列表
+	 */
+	List<UserAnnouncementVO> listUserAnnouncements(@Param("userId") Long userId);
 
 }

--- a/ballcat-business-notify/ballcat-notify-biz/src/main/java/org/ballcat/business/notify/service/AnnouncementService.java
+++ b/ballcat-business-notify/ballcat-notify-biz/src/main/java/org/ballcat/business/notify/service/AnnouncementService.java
@@ -1,5 +1,7 @@
 package org.ballcat.business.notify.service;
 
+import java.util.List;
+
 import org.ballcat.business.notify.model.dto.AnnouncementDTO;
 import org.ballcat.business.notify.model.entity.Announcement;
 import org.ballcat.business.notify.model.qo.AnnouncementQO;
@@ -8,8 +10,6 @@ import org.ballcat.common.model.domain.PageParam;
 import org.ballcat.common.model.domain.PageResult;
 import org.ballcat.mybatisplus.service.ExtendService;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 /**
  * 公告信息
@@ -67,12 +67,5 @@ public interface AnnouncementService extends ExtendService<Announcement> {
 	 * @return List<Announcement>
 	 */
 	List<Announcement> listUnPulled(Long userId);
-
-	/**
-	 * 获取用户拉取过的发布中，且满足失效时间的公告信息
-	 * @param userId 用户id
-	 * @return List<Announcement>
-	 */
-	List<Announcement> listActiveAnnouncements(Long userId);
 
 }

--- a/ballcat-business-notify/ballcat-notify-biz/src/main/java/org/ballcat/business/notify/service/UserAnnouncementService.java
+++ b/ballcat-business-notify/ballcat-notify-biz/src/main/java/org/ballcat/business/notify/service/UserAnnouncementService.java
@@ -1,8 +1,11 @@
 package org.ballcat.business.notify.service;
 
+import java.util.List;
+
 import org.ballcat.business.notify.model.entity.UserAnnouncement;
 import org.ballcat.business.notify.model.qo.UserAnnouncementQO;
 import org.ballcat.business.notify.model.vo.UserAnnouncementPageVO;
+import org.ballcat.business.notify.model.vo.UserAnnouncementVO;
 import org.ballcat.common.model.domain.PageParam;
 import org.ballcat.common.model.domain.PageResult;
 import org.ballcat.mybatisplus.service.ExtendService;
@@ -21,6 +24,13 @@ public interface UserAnnouncementService extends ExtendService<UserAnnouncement>
 	 * @return PageResult<AnnouncementVO> 分页数据
 	 */
 	PageResult<UserAnnouncementPageVO> queryPage(PageParam pageParam, UserAnnouncementQO qo);
+
+	/**
+	 * 获取用户拉取过的发布中，且满足失效时间的公告信息
+	 * @param userId 用户id
+	 * @return List<Announcement>
+	 */
+	List<UserAnnouncementVO> listActiveAnnouncements(Long userId);
 
 	/**
 	 * 根据用户ID和公告id初始化一个新的用户公告关联对象

--- a/ballcat-business-notify/ballcat-notify-biz/src/main/java/org/ballcat/business/notify/service/impl/AnnouncementServiceImpl.java
+++ b/ballcat-business-notify/ballcat-notify-biz/src/main/java/org/ballcat/business/notify/service/impl/AnnouncementServiceImpl.java
@@ -1,5 +1,12 @@
 package org.ballcat.business.notify.service.impl;
 
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
 import com.baomidou.mybatisplus.extension.toolkit.SqlHelper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,13 +37,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * 公告信息
@@ -188,17 +188,7 @@ public class AnnouncementServiceImpl extends ExtendServiceImpl<AnnouncementMappe
 	 */
 	@Override
 	public List<Announcement> listUnPulled(Long userId) {
-		return baseMapper.listUserAnnouncements(userId, false);
-	}
-
-	/**
-	 * 获取用户拉取过的发布中，且满足失效时间的公告信息
-	 * @param userId 用户id
-	 * @return List<Announcement>
-	 */
-	@Override
-	public List<Announcement> listActiveAnnouncements(Long userId) {
-		return baseMapper.listUserAnnouncements(userId, true);
+		return baseMapper.listUnPulledUserAnnouncements(userId);
 	}
 
 	/**

--- a/ballcat-business-notify/ballcat-notify-biz/src/main/java/org/ballcat/business/notify/service/impl/UserAnnouncementServiceImpl.java
+++ b/ballcat-business-notify/ballcat-notify-biz/src/main/java/org/ballcat/business/notify/service/impl/UserAnnouncementServiceImpl.java
@@ -1,17 +1,19 @@
 package org.ballcat.business.notify.service.impl;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.ballcat.business.notify.enums.UserAnnouncementStateEnum;
 import org.ballcat.business.notify.mapper.UserAnnouncementMapper;
 import org.ballcat.business.notify.model.entity.UserAnnouncement;
 import org.ballcat.business.notify.model.qo.UserAnnouncementQO;
 import org.ballcat.business.notify.model.vo.UserAnnouncementPageVO;
+import org.ballcat.business.notify.model.vo.UserAnnouncementVO;
 import org.ballcat.business.notify.service.UserAnnouncementService;
 import org.ballcat.common.model.domain.PageParam;
 import org.ballcat.common.model.domain.PageResult;
 import org.ballcat.mybatisplus.service.impl.ExtendServiceImpl;
 import org.springframework.stereotype.Service;
-
-import java.time.LocalDateTime;
 
 /**
  * 用户公告表
@@ -31,6 +33,16 @@ public class UserAnnouncementServiceImpl extends ExtendServiceImpl<UserAnnouncem
 	@Override
 	public PageResult<UserAnnouncementPageVO> queryPage(PageParam pageParam, UserAnnouncementQO qo) {
 		return baseMapper.queryPage(pageParam, qo);
+	}
+
+	/**
+	 * 获取用户拉取过的发布中，且满足失效时间的公告信息
+	 * @param userId 用户id
+	 * @return List<Announcement>
+	 */
+	@Override
+	public List<UserAnnouncementVO> listActiveAnnouncements(Long userId) {
+		return baseMapper.listUserAnnouncements(userId);
 	}
 
 	/**

--- a/ballcat-business-notify/ballcat-notify-biz/src/main/resources/mapper/AnnouncementMapper.xml
+++ b/ballcat-business-notify/ballcat-notify-biz/src/main/resources/mapper/AnnouncementMapper.xml
@@ -40,23 +40,15 @@
     </select>
 
 	<!-- com.baomidou.mybatisplus.core.metadata.TableInfo.initResultMapIfNeed -->
-	<select id="listUserAnnouncements" resultMap="mybatis-plus_Announcement">
+	<select id="listUnPulledUserAnnouncements" resultMap="mybatis-plus_Announcement">
 		SELECT
 		<include refid="Base_Alias_Column_List"/>
-		FROM
-		notify_announcement a
-		LEFT JOIN notify_user_announcement ua
-		ON ua.user_id = #{userId} AND ua.announcement_id = a.id
-		WHERE
-		a.STATUS = 1
-		AND ( a.immortal = 1 OR a.deadline > now() )
-		<choose>
-			<when test="pulled">
-				AND ua.id IS NOT NULL
-			</when>
-			<otherwise>
-				AND ua.id IS NULL
-			</otherwise>
-		</choose>
+		FROM notify_announcement a
+		WHERE a.STATUS = 1
+		  AND ( a.immortal = 1 OR a.deadline > now() )
+		  AND NOT EXISTS(
+		     SELECT 1 FROM notify_user_announcement
+		    WHERE user_id = #{userId} AND announcement_id = a.id
+		  )
 	</select>
 </mapper>

--- a/ballcat-business-notify/ballcat-notify-biz/src/main/resources/mapper/UserAnnouncementMapper.xml
+++ b/ballcat-business-notify/ballcat-notify-biz/src/main/resources/mapper/UserAnnouncementMapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.ballcat.business.notify.mapper.UserAnnouncementMapper">
+
+    <select id="listUserAnnouncements" resultType="org.ballcat.business.notify.model.vo.UserAnnouncementVO">
+        SELECT
+        a.id, a.title, a.content, ua.state,
+        a.create_by, a.create_time, a.update_time, su.username create_username
+        FROM notify_user_announcement ua, notify_announcement a
+        LEFT JOIN sys_user su ON a.create_by = su.user_id
+        WHERE ua.announcement_id = a.id
+        AND ua.user_id = #{userId}
+        AND a.STATUS = 1
+        AND ua.state = 0
+        AND ( a.immortal = 1 OR a.deadline > now() )
+    </select>
+</mapper>

--- a/ballcat-business-notify/ballcat-notify-controller/src/main/java/org/ballcat/business/notify/controller/AnnouncementController.java
+++ b/ballcat-business-notify/ballcat-notify-controller/src/main/java/org/ballcat/business/notify/controller/AnnouncementController.java
@@ -1,22 +1,24 @@
 package org.ballcat.business.notify.controller;
 
-import org.ballcat.log.operation.annotation.CreateOperationLogging;
-import org.ballcat.log.operation.annotation.DeleteOperationLogging;
-import org.ballcat.log.operation.annotation.UpdateOperationLogging;
+import java.util.List;
+
+import javax.validation.Valid;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.ballcat.business.notify.model.dto.AnnouncementDTO;
+import org.ballcat.business.notify.model.qo.AnnouncementQO;
+import org.ballcat.business.notify.model.vo.AnnouncementPageVO;
+import org.ballcat.business.notify.service.AnnouncementService;
 import org.ballcat.common.model.domain.PageParam;
 import org.ballcat.common.model.domain.PageResult;
 import org.ballcat.common.model.result.BaseResultCode;
 import org.ballcat.common.model.result.R;
+import org.ballcat.log.operation.annotation.CreateOperationLogging;
+import org.ballcat.log.operation.annotation.DeleteOperationLogging;
+import org.ballcat.log.operation.annotation.UpdateOperationLogging;
 import org.ballcat.security.annotation.Authorize;
-import org.ballcat.business.notify.model.dto.AnnouncementDTO;
-import org.ballcat.business.notify.model.entity.Announcement;
-import org.ballcat.business.notify.model.qo.AnnouncementQO;
-import org.ballcat.business.notify.model.vo.AnnouncementPageVO;
-import org.ballcat.business.notify.service.AnnouncementService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import org.ballcat.security.core.PrincipalAttributeAccessor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,9 +32,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.validation.Valid;
-import java.util.List;
-
 /**
  * 公告信息
  *
@@ -45,8 +44,6 @@ import java.util.List;
 public class AnnouncementController {
 
 	private final AnnouncementService announcementService;
-
-	private final PrincipalAttributeAccessor principalAttributeAccessor;
 
 	/**
 	 * 分页查询
@@ -137,14 +134,6 @@ public class AnnouncementController {
 	public R<List<String>> uploadImages(@RequestParam("files") List<MultipartFile> files) {
 		List<String> objectNames = announcementService.uploadImages(files);
 		return R.ok(objectNames);
-	}
-
-	@GetMapping("/user")
-	@Authorize("hasPermission('notify:userannouncement:read')")
-	@Operation(summary = "用户公告信息", description = "用户公告信息")
-	public R<List<Announcement>> getUserAnnouncements() {
-		Long userId = principalAttributeAccessor.getUserId();
-		return R.ok(announcementService.listActiveAnnouncements(userId));
 	}
 
 }

--- a/ballcat-business-notify/ballcat-notify-controller/src/main/java/org/ballcat/business/notify/controller/UserAnnouncementController.java
+++ b/ballcat-business-notify/ballcat-notify-controller/src/main/java/org/ballcat/business/notify/controller/UserAnnouncementController.java
@@ -1,16 +1,18 @@
 package org.ballcat.business.notify.controller;
 
-import org.ballcat.common.model.domain.PageParam;
-import org.ballcat.common.model.domain.PageResult;
-import org.ballcat.common.model.result.R;
-import org.ballcat.security.annotation.Authorize;
-import org.ballcat.security.core.PrincipalAttributeAccessor;
-import org.ballcat.business.notify.model.qo.UserAnnouncementQO;
-import org.ballcat.business.notify.model.vo.UserAnnouncementPageVO;
-import org.ballcat.business.notify.service.UserAnnouncementService;
+import java.util.List;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.ballcat.business.notify.model.qo.UserAnnouncementQO;
+import org.ballcat.business.notify.model.vo.UserAnnouncementPageVO;
+import org.ballcat.business.notify.model.vo.UserAnnouncementVO;
+import org.ballcat.business.notify.service.UserAnnouncementService;
+import org.ballcat.common.model.domain.PageParam;
+import org.ballcat.common.model.domain.PageResult;
+import org.ballcat.common.model.result.R;
+import org.ballcat.security.core.PrincipalAttributeAccessor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -40,15 +42,20 @@ public class UserAnnouncementController {
 	 * @return R 通用返回体
 	 */
 	@GetMapping("/page")
-	@Authorize("hasPermission('notify:userannouncement:read')")
 	@Operation(summary = "分页查询", description = "分页查询")
 	public R<PageResult<UserAnnouncementPageVO>> getUserAnnouncementPage(@Validated PageParam pageParam,
 			UserAnnouncementQO userAnnouncementQO) {
 		return R.ok(userAnnouncementService.queryPage(pageParam, userAnnouncementQO));
 	}
 
+	@GetMapping("/list")
+	@Operation(summary = "用户公告信息", description = "用户公告信息")
+	public R<List<UserAnnouncementVO>> getUserAnnouncements() {
+		Long userId = principalAttributeAccessor.getUserId();
+		return R.ok(userAnnouncementService.listActiveAnnouncements(userId));
+	}
+
 	@PatchMapping("/read/{announcementId}")
-	@Authorize("hasPermission('notify:userannouncement:read')")
 	@Operation(summary = "用户公告已读上报", description = "用户公告已读上报")
 	public R<Void> readAnnouncement(@PathVariable("announcementId") Long announcementId) {
 		Long userId = principalAttributeAccessor.getUserId();

--- a/ballcat-business-notify/ballcat-notify-model/src/main/java/org/ballcat/business/notify/model/vo/UserAnnouncementVO.java
+++ b/ballcat-business-notify/ballcat-notify-model/src/main/java/org/ballcat/business/notify/model/vo/UserAnnouncementVO.java
@@ -1,0 +1,68 @@
+package org.ballcat.business.notify.model.vo;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+/**
+ * 用户公告表
+ *
+ * @author evil0th 2024-1-30 16:04:53
+ */
+@Data
+@Schema(title = "用户公告分页VO")
+public class UserAnnouncementVO implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * 公告ID
+	 */
+	@Schema(title = "ID")
+	private Long id;
+
+	/**
+	 * 标题
+	 */
+	@Schema(title = "标题")
+	private String title;
+
+	/**
+	 * 内容
+	 */
+	@Schema(title = "内容")
+	private String content;
+
+	/**
+	 * 状态，已读(1)|未读(0)
+	 */
+	@Schema(title = "状态，已读(1)|未读(0)")
+	private Integer state;
+
+	/**
+	 * 创建人ID
+	 */
+	@Schema(title = "创建人ID")
+	private Integer createBy;
+
+	/**
+	 * 创建人名称
+	 */
+	@Schema(title = "创建人名称")
+	private String createUsername;
+
+	/**
+	 * 创建时间
+	 */
+	@Schema(title = "创建时间")
+	private LocalDateTime createTime;
+
+	/**
+	 * 更新时间
+	 */
+	@Schema(title = "更新时间")
+	private LocalDateTime updateTime;
+
+}


### PR DESCRIPTION
“此state非彼status”，导致前端点击“我知道了”无法将通知公告标记为已读。
 ref ballcat-admin-ui-vue3[#36](https://github.com/ballcat-projects/ballcat-admin-ui-vue3/pull/36)